### PR TITLE
Handle duplicate document inserts and avoid unnecessary embedding API calls

### DIFF
--- a/backend/rag_modules/vector_store.py
+++ b/backend/rag_modules/vector_store.py
@@ -62,3 +62,9 @@ def fetch_relevant_documents(conn, query_embedding, top_n=5, threshold=0.7):
     # Sort by similarity and return top_n
     top_docs = sorted(docs, key=lambda x: x["similarity"], reverse=True)[:top_n]
     return top_docs
+
+
+def document_exists(conn, content):
+    cursor = conn.cursor()
+    cursor.execute("SELECT 1 FROM documents WHERE content = ?", (content,))
+    return cursor.fetchone() is not None

--- a/backend/rag_modules/vector_store.py
+++ b/backend/rag_modules/vector_store.py
@@ -18,7 +18,7 @@ def create_documents_table(conn):
         """
         CREATE TABLE IF NOT EXISTS documents (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            content TEXT,
+            content TEXT UNIQUE,
             embedding TEXT
         )
         """


### PR DESCRIPTION
### feat
- Add logic to avoid redundant embedding requests by checking for existing documents before processing
### chore
- Add a UNIQUE constraint to the content column in the documents table to ensure only unique documents are stored and prevent duplicate